### PR TITLE
Updating Vertcoin Derivation to match Ledger Live

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -662,7 +662,7 @@ void menu_generate(uint32_t dummy) {
             derivePath[1] = 0x80000069;
             break;
         case COIN_TYPE_VERTCOIN:
-            derivePath[1] = 0x8000001c;
+            derivePath[1] = 0x80000080;
             break;
         case COIN_TYPE_VIACOIN:
             derivePath[1] = 0x8000000e;


### PR DESCRIPTION
Ledger Live app (and previously, Chrome App) utilises (incorrectly) m/49'/128'/0' as the derivation path, whereas the HODL app (correctly) uses the m/49'/28'/0' path. If users use HODL to generate an address, any funds sent there will not show up in Ledger Live, therefore it would be wise to update HODL to the incorrect derivation path to match the rest of the Ledger ecosystem.